### PR TITLE
Adds Port Launch & XACRO Arguments

### DIFF
--- a/robotiq_description/launch/robotiq_control.launch.py
+++ b/robotiq_description/launch/robotiq_control.launch.py
@@ -69,6 +69,13 @@ def generate_launch_description():
             name="launch_rviz", default_value="false", description="Launch RViz?"
         )
     )
+    args.append(
+        launch.actions.DeclareLaunchArgument(
+            name="com_port",
+            default_value="/dev/ttyUSB1",
+            description="Port for communicating with Robotiq hardware",
+        )
+    )
 
     robot_description_content = Command(
         [
@@ -77,8 +84,12 @@ def generate_launch_description():
             LaunchConfiguration("model"),
             " ",
             "use_fake_hardware:=false",
+            " ",
+            "com_port:=",
+            LaunchConfiguration("com_port"),
         ]
     )
+
     robot_description_param = {
         "robot_description": launch_ros.parameter_descriptions.ParameterValue(
             robot_description_content, value_type=str

--- a/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_2f_140_gripper.urdf.xacro
@@ -2,12 +2,13 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
     <!-- parameters -->
     <xacro:arg name="use_fake_hardware" default="true" />
+    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_140_macro.urdf.xacro" />
 
     <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)">
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>

--- a/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
@@ -2,12 +2,13 @@
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="robotiq_gripper">
     <!-- parameters -->
     <xacro:arg name="use_fake_hardware" default="true" />
+    <xacro:arg name="com_port" default="/dev/ttyUSB0" />
 
     <!-- Import macros -->
     <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />
 
     <link name="world" />
-    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)">
+    <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)" com_port="$(arg com_port)">
         <origin xyz="0 0 0" rpy="0 0 0" />
     </xacro:robotiq_gripper>
 </robot>


### PR DESCRIPTION
Currently there is no way to configure the `com_port`, except for manually editing the file. This PR adds a `com_port` launch and XACRO argument for users to switch the `com_port` with runtime / command-line arguments.
